### PR TITLE
Set up permanent ami id to "ami-022d4249382309a48" (CORE-228)

### DIFF
--- a/data.tf
+++ b/data.tf
@@ -14,7 +14,8 @@ data "aws_ami" "ubuntu_20_04" {
   most_recent = true
   filter {
     name   = "name"
-    values = ["ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-*"]
+    values = ["ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20211118"]
+    # Ubuntu 20.04 LTS amd64 image at us-east-1. If upgrade is needed, you would need to re-connect to openvpn.
   }
   filter {
     name   = "virtualization-type"

--- a/data.tf
+++ b/data.tf
@@ -14,8 +14,9 @@ data "aws_ami" "ubuntu_20_04" {
   most_recent = true
   filter {
     name   = "name"
+    # Ubuntu 20.04 LTS amd64 image in us-east-1. If upgrade is needed, you would need to re-connect to openvpn.
     values = ["ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20211118"]
-    # Ubuntu 20.04 LTS amd64 image at us-east-1. If upgrade is needed, you would need to re-connect to openvpn.
+
   }
   filter {
     name   = "virtualization-type"

--- a/main.tf
+++ b/main.tf
@@ -25,7 +25,7 @@ resource "aws_security_group" "this" {
     Env       = var.env
     Name      = local.name
   }
-  
+
   lifecycle {
     create_before_destroy = true
   }
@@ -33,7 +33,8 @@ resource "aws_security_group" "this" {
 
 # EC2
 resource "aws_instance" "this" {
-  ami                    = join("", data.aws_ami.ubuntu_20_04.*.id)
+  ami                    =  "ami-022d4249382309a48"
+# ami                    =  join("", data.aws_ami.ubuntu_20_04.*.id)
   instance_type          = var.instance_type
   iam_instance_profile   = aws_iam_instance_profile.this.name
   subnet_id              = var.private_subnets[0]
@@ -41,7 +42,7 @@ resource "aws_instance" "this" {
   vpc_security_group_ids = concat(var.ext_security_groups, [
     aws_security_group.this.id
   ])
-  
+
   disable_api_termination     = var.vpn_enabled ? true : false
   associate_public_ip_address = false
 

--- a/main.tf
+++ b/main.tf
@@ -33,11 +33,11 @@ resource "aws_security_group" "this" {
 
 # EC2
 resource "aws_instance" "this" {
- ami                    =  join("", data.aws_ami.ubuntu_20_04.*.id)
-  instance_type          = var.instance_type
-  iam_instance_profile   = aws_iam_instance_profile.this.name
-  subnet_id              = var.private_subnets[0]
-  key_name               = var.ec2_key_pair_name
+  ami                  = join("", data.aws_ami.ubuntu_20_04.*.id)
+  instance_type        = var.instance_type
+  iam_instance_profile = aws_iam_instance_profile.this.name
+  subnet_id            = var.private_subnets[0]
+  key_name             = var.ec2_key_pair_name
   vpc_security_group_ids = concat(var.ext_security_groups, [
     aws_security_group.this.id
   ])
@@ -48,7 +48,7 @@ resource "aws_instance" "this" {
     ignore_changes = all
   }
 
-  user_data              = var.vpn_enabled ? data.template_file.ec2_user_data.rendered : null
+  user_data = var.vpn_enabled ? data.template_file.ec2_user_data.rendered : null
 
   tags = {
     Terraform = "true"

--- a/main.tf
+++ b/main.tf
@@ -33,8 +33,7 @@ resource "aws_security_group" "this" {
 
 # EC2
 resource "aws_instance" "this" {
-  ami                    =  "ami-022d4249382309a48"
-# ami                    =  join("", data.aws_ami.ubuntu_20_04.*.id)
+ ami                    =  join("", data.aws_ami.ubuntu_20_04.*.id)
   instance_type          = var.instance_type
   iam_instance_profile   = aws_iam_instance_profile.this.name
   subnet_id              = var.private_subnets[0]
@@ -43,7 +42,6 @@ resource "aws_instance" "this" {
     aws_security_group.this.id
   ])
 
-  disable_api_termination     = var.vpn_enabled ? true : false
   associate_public_ip_address = false
 
   lifecycle {


### PR DESCRIPTION
#### What's new:

 - Set up to permanent "ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20211118"
- turn off EC2 destroy protection
