### PR TITLE
CORE-634 ubuntu-version-not-found-terraform-aws-ec-2-openvpn-connector

### DIFF
--- a/data.tf
+++ b/data.tf
@@ -10,17 +10,12 @@ data "template_file" "ec2_user_data" {
   }
 }
 
-data "aws_ami" "ubuntu_20_04" {
+data "aws_ami" "ubuntu_22_04" {
   most_recent = true
   filter {
     name   = "name"
-    # Ubuntu 20.04 LTS amd64 image in us-east-1. If upgrade is needed, you would need to re-connect to openvpn.
-    values = ["ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20211118"]
-
-  }
-  filter {
-    name   = "virtualization-type"
-    values = ["hvm"]
+    # Ubuntu 22.04 LTS amd64 image in us-east-1. If upgrade is needed, you would need to re-connect to openvpn.
+    values = ["ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20230601"]
   }
   owners = ["099720109477"] # Canonical
 }

--- a/main.tf
+++ b/main.tf
@@ -33,7 +33,7 @@ resource "aws_security_group" "this" {
 
 # EC2
 resource "aws_instance" "this" {
-  ami                  = join("", data.aws_ami.ubuntu_20_04.*.id)
+  ami                  = join("", data.aws_ami.ubuntu_22_04.*.id)
   instance_type        = var.instance_type
   iam_instance_profile = aws_iam_instance_profile.this.name
   subnet_id            = var.private_subnets[0]


### PR DESCRIPTION
#### What's new:

- Ubuntu image found
- Data source updated

#### Testing done:

<img width="934" alt="Screenshot 2023-12-02 at 00 25 45" src="https://github.com/hazelops/terraform-aws-ec2-openvpn-connector/assets/24703846/18acb28f-eef5-4d86-89aa-926795c827bc">

<img width="1346" alt="Screenshot 2023-12-02 at 00 25 54" src="https://github.com/hazelops/terraform-aws-ec2-openvpn-connector/assets/24703846/609d60db-d6ae-4ef7-a07d-7d4fd4560b7f">
